### PR TITLE
Fixed Thread Sleep and messageSize

### DIFF
--- a/Mike.MQShootout/ShootoutTest.cs
+++ b/Mike.MQShootout/ShootoutTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 
 namespace Mike.MQShootout
 {
@@ -18,9 +18,7 @@ namespace Mike.MQShootout
             var receivingMachine = new MessageReceivingMachine(messageReceiver, numberOfMessages);
             var sendingMachine = new MessageSendingMachine(messageSender);
 
-            Thread.Sleep(messageSizeInBytes);
-
-            sendingMachine.RunTest(1000, numberOfMessages);
+            sendingMachine.RunTest(messageSizeInBytes, numberOfMessages);
 
             receivingMachine.WaitForCompletion();            
         }


### PR DESCRIPTION
Thread was sleeping "messageSizeInBytes" milliseconds, this is unnecessary and the variable use to determine the amount of sleep time was wrong.

The RunTest() method was starting up with message size fixed to 1000 instead of using the value in messageSizeInBytes.
